### PR TITLE
Verwijzing naar PvE

### DIFF
--- a/OIN-SubOIN_in_PkioCert.md
+++ b/OIN-SubOIN_in_PkioCert.md
@@ -7,7 +7,7 @@ Onderstaande beschrijving is voorgelegd aan de TSP's voor verificatie.
 </aside>
 
 ## Inleiding
-Dit hoofdstuk beschrijft Invulling (Sub)OIN en Organisatienaam, en –onderdeel/voorziening/samenwerking in velden van het PKIO certificaat [[Eisen Pkioverheid]].
+Dit hoofdstuk beschrijft Invulling (Sub)OIN en Organisatienaam, en –onderdeel/voorziening/samenwerking in velden van het PKIO certificaat [[Eisen Pkioverheid]] (deel 3g).
 
 | Field/Attribute  | C\*  |  |  |
 | --- | --- | --- | --- |

--- a/OIN-SubOIN_in_PkioCert.md
+++ b/OIN-SubOIN_in_PkioCert.md
@@ -7,7 +7,7 @@ Onderstaande beschrijving is voorgelegd aan de TSP's voor verificatie.
 </aside>
 
 ## Inleiding
-Dit hoofdstuk beschrijft Invulling (Sub)OIN en Organisatienaam, en –onderdeel/voorziening/samenwerking in velden van het PKIO certificaat [[Eisen Pkioverheid]] [[PKI PvE]] )
+Dit hoofdstuk beschrijft Invulling (Sub)OIN en Organisatienaam, en –onderdeel/voorziening/samenwerking in velden van het PKIO certificaat [[Eisen Pkioverheid]].
 
 | Field/Attribute  | C\*  |  |  |
 | --- | --- | --- | --- |


### PR DESCRIPTION
De directe link naar een PDF-bestand van de Programma van Eisen (PKIoverheid) is veranderlijk gebleken. Voorstel enkel naar de HTML-pagina op logius.nl te verwijzen waar de links worden onderhouden.