### PR TITLE
Toelichting toegevoegd: BRIN- en UZI-prefixes worden niet opgenomen in OIN-register

### DIFF
--- a/ch06_Data Architectuur.md
+++ b/ch06_Data Architectuur.md
@@ -25,14 +25,14 @@ Een aangesloten overheidsregister krijgt een prefix (per uniek nummer) als het r
 | **00000003** | [=KVK-nummer=]| Handelsregister – Het [=KVK-nummer=] wordt gebruikt door private partijen in de communicatie met de overheid. Een nieuw [=OIN=] wordt altijd gebaseerd op het KVK-nummer indien aanwwezig |
 | **00000004** | subnummer | SubOIN register |
 | **00000005** | vrij | nog aan te wijzen |
-| **00000006** | Logius [=OIN=] Hoofdnummer | Door Logius uitgegeven [=OIN=] Hoofdnummers aan organisaties die in aanmerking komen voor een [=OIN=] maar waarvoor geen geschikt nummer uit de overige prefix categorieën beschikbaar is. (*) |
-| **00000007** | BRIN nummer | De Basisregistratie Instellingen (BRIN) is een register van onderwijsinstellingen dat door DUO wordt beheerd in opdracht van het Ministerie van OCW.|
-| **00000008** | Buitenlandse nummers| Op verzoek van een [=SubOIN-beheerder=] door Logius uitgegeven nummers voor buitenlandse organisaties die niet in het Handelsregister zijn ingeschreven|
-| **00000009** | UZI-nummer| Het Unieke Zorgverlener Identificatie Register (UZI-register) is de organisatie die de unieke identificatie van zorgaanbieders en indicatieorganen in het elektronisch verkeer mogelijk maakt.|
+| **00000006** | Logius [=OIN=] Hoofdnummer | Door Logius uitgegeven [=OIN=] Hoofdnummers aan organisaties die in aanmerking komen voor een [=OIN=] maar waarvoor geen geschikt nummer uit de overige prefix categorieën beschikbaar is. (*1) |
+| **00000007** | BRIN nummer | De Basisregistratie Instellingen (BRIN) is een register van onderwijsinstellingen dat door DUO wordt beheerd in opdracht van het Ministerie van OCW. (*2)|
+| **00000008** | Buitenlandse nummers| Op verzoek van een [=SubOIN-beheerder=] door Logius uitgegeven nummers voor buitenlandse organisaties die niet in het Handelsregister zijn ingeschreven |
+| **00000009** | UZI-nummer| Het Unieke Zorgverlener Identificatie Register (UZI-register) is de organisatie die de unieke identificatie van zorgaanbieders en indicatieorganen in het elektronisch verkeer mogelijk maakt. (*2)|
 | **00000099** | Test OIN's| Elke organisatie mag een test OIN gebruiken mits voorzien van deze prefix.|
 
- (*) *00000006 Logius OIN Hoofdnummer: Voor organisaties uit het caribisch deel van het Koninkrijk der Nederlanden is dit nummer opgebouwd als 4 posities landnummer gevolgd door 5 posities volgnummer, conform landentabel BRP.* <br>
- (*) *Nummers met een BRIN-prefix (00000007) en een UZI-prefix (00000009) worden niet opgenomen in het centrale OIN-register.*
+ (*1) *00000006 Logius OIN Hoofdnummer: Voor organisaties uit het caribisch deel van het Koninkrijk der Nederlanden is dit nummer opgebouwd als 4 posities landnummer gevolgd door 5 posities volgnummer, conform landentabel BRP.* <br>
+ (*2) *Nummers met een BRIN-prefix (00000007) en een UZI-prefix (00000009) worden niet opgenomen in het centrale OIN-register.*
 
 
 ## Voorbeeld OIN structuur

--- a/ch06_Data Architectuur.md
+++ b/ch06_Data Architectuur.md
@@ -18,7 +18,8 @@ De lengte van het [=OIN=] is 20 posities, omdat dit wordt opgenomen in het *subj
 
 Een aangesloten overheidsregister krijgt een prefix (per uniek nummer) als het register wordt toegevoegd aan het OIN-stelsel. Dit wordt ook een OIN register genoemd. De prefix tabel wordt als aparte lijst beheerd door de beheerder van het OIN-stelsel en wordt gepubliceerd op de website.
 
-
+> **Let op:**  
+> Nummers met een **BRIN**-prefix (00000007) en een **UZI**-prefix (00000009) worden **niet opgenomen** in het centrale OIN-register. Deze nummers zijn wel herkenbaar via hun prefix, maar maken géén deel uit van het primaire OIN-register.
 
 | **Prefix** | **Identificerend nummer** | **Bron**|
 |------------|-----------------------------------------|---|

--- a/ch06_Data Architectuur.md
+++ b/ch06_Data Architectuur.md
@@ -18,9 +18,6 @@ De lengte van het [=OIN=] is 20 posities, omdat dit wordt opgenomen in het *subj
 
 Een aangesloten overheidsregister krijgt een prefix (per uniek nummer) als het register wordt toegevoegd aan het OIN-stelsel. Dit wordt ook een OIN register genoemd. De prefix tabel wordt als aparte lijst beheerd door de beheerder van het OIN-stelsel en wordt gepubliceerd op de website.
 
-> **Let op:**  
-> Nummers met een **BRIN**-prefix (00000007) en een **UZI**-prefix (00000009) worden **niet opgenomen** in het centrale OIN-register. 
-
 | **Prefix** | **Identificerend nummer** | **Bron**|
 |------------|-----------------------------------------|---|
 | **00000001** | [=RSIN=]| Handelsregister |
@@ -34,7 +31,8 @@ Een aangesloten overheidsregister krijgt een prefix (per uniek nummer) als het r
 | **00000009** | UZI-nummer| Het Unieke Zorgverlener Identificatie Register (UZI-register) is de organisatie die de unieke identificatie van zorgaanbieders en indicatieorganen in het elektronisch verkeer mogelijk maakt.|
 | **00000099** | Test OIN's| Elke organisatie mag een test OIN gebruiken mits voorzien van deze prefix.|
 
- (*) *00000006 Logius OIN Hoofdnummer: Voor organisaties uit het caribisch deel van het Koninkrijk der Nederlanden is dit nummer opgebouwd als 4 posities landnummer gevolgd door 5 posities volgnummer, conform landentabel BRP.*
+ (*) *00000006 Logius OIN Hoofdnummer: Voor organisaties uit het caribisch deel van het Koninkrijk der Nederlanden is dit nummer opgebouwd als 4 posities landnummer gevolgd door 5 posities volgnummer, conform landentabel BRP.* <br>
+ (*) *Nummers met een BRIN-prefix (00000007) en een UZI-prefix (00000009) worden niet opgenomen in het centrale OIN-register.*
 
 
 ## Voorbeeld OIN structuur

--- a/ch06_Data Architectuur.md
+++ b/ch06_Data Architectuur.md
@@ -19,7 +19,7 @@ De lengte van het [=OIN=] is 20 posities, omdat dit wordt opgenomen in het *subj
 Een aangesloten overheidsregister krijgt een prefix (per uniek nummer) als het register wordt toegevoegd aan het OIN-stelsel. Dit wordt ook een OIN register genoemd. De prefix tabel wordt als aparte lijst beheerd door de beheerder van het OIN-stelsel en wordt gepubliceerd op de website.
 
 > **Let op:**  
-> Nummers met een **BRIN**-prefix (00000007) en een **UZI**-prefix (00000009) worden **niet opgenomen** in het centrale OIN-register. Deze nummers zijn wel herkenbaar via hun prefix, maar maken géén deel uit van het primaire OIN-register.
+> Nummers met een **BRIN**-prefix (00000007) en een **UZI**-prefix (00000009) worden **niet opgenomen** in het centrale OIN-register. 
 
 | **Prefix** | **Identificerend nummer** | **Bron**|
 |------------|-----------------------------------------|---|


### PR DESCRIPTION
fixes #28 

Een toelichting toegevoegd boven de prefix-tabel in de OIN-register documentatie.